### PR TITLE
Remove exception when the data in the comment segment is truncated

### DIFF
--- a/plugins/ps5_elf.py
+++ b/plugins/ps5_elf.py
@@ -1544,12 +1544,15 @@ class ElfPlugin(ida_idaapi.plugin_t):
 
 			data = f.read(struct.calcsize('2I'))
 			if len(data) != struct.calcsize('2I'):
-				raise RuntimeError('Truncated data at comment segment.')
+				print('Truncated data at comment segment.')
+				return False
+				
 			max_length, length = struct.unpack('<2I', data)
 
 			value = f.read(length)
 			if len(value) != length:
-				raise RuntimeError('Truncated data at comment segment.')
+				print('Truncated data at comment segment.')
+				return False;
 
 			# Try to decode value as UTF-8 string.
 			try:


### PR DESCRIPTION
While using the plugin I noticed that the RuntimeError `Truncated data at comment segment.` appears on all .sprx file dumped from the firmware 4.03, this makes the ELF processing fail and as result, the name mangling are not demangled.

In order to fix that, we can just return `False` instead trigger the exception.

With the exception:

![image](https://github.com/flatz/ida_ps5_elf_plugin/assets/22428720/3ef5ac3c-0694-4577-a715-114fd82357d5)


Returning `False` instead:

![image](https://github.com/flatz/ida_ps5_elf_plugin/assets/22428720/940b09ce-0aeb-4a40-a3c8-2412d09276d6)
